### PR TITLE
Enable drop_invalid_header_fields for overwatch alb

### DIFF
--- a/modules/aws_ecs/loadbalancers.tf
+++ b/modules/aws_ecs/loadbalancers.tf
@@ -2,6 +2,8 @@ resource "aws_lb" "this" {
   name         = "${var.deployment_name}-alb"
   idle_timeout = var.alb_idle_timeout
 
+  drop_invalid_header_fields = true
+
   security_groups = [aws_security_group.alb.id]
   subnets         = var.subnet_ids
 }


### PR DESCRIPTION
This pull request includes a small but important change to the `modules/aws_ecs/loadbalancers.tf` file. The change adds a new configuration to the AWS Load Balancer resource to improve security and reliability.

* [`modules/aws_ecs/loadbalancers.tf`](diffhunk://#diff-33c941d39ef7dc34f559ca6ab40dd1110c664f609e190f696a77a60d6db107b2R5-R6): Added `drop_invalid_header_fields = true` to the `aws_lb` resource to ensure invalid headers are dropped, enhancing security.